### PR TITLE
add keyboard-interactive auth response tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,19 @@ All notable changes to Tabby-MCP will be documented in this file.
 
 > ⚠️ **Prerelease.** Published to GitHub only, not to npm. Verified by typecheck, smoke regression checks, and a production build; **not verified by a manual run inside a real Tabby/Electron session**. Dialog focus restoration, live SFTP transfer cancellation, and multi-instance port handover still need hands-on testing before a stable 1.6.3.
 
+### ✨ Added
+- **SSH keyboard-interactive authentication**: added `submit_keyboard_interactive_response` for MFA/TOTP and password prompts rendered by Tabby's authentication panel rather than the terminal PTY. Prompt metadata supports both current string prompts and object-shaped prompts from older Tabby releases.
+- **Live Jumpserver validation**: verified end-to-end MFA submission and successful arrival at the Jumpserver asset menu on Tabby 1.0.229 and 1.0.235 for macOS.
+
 ### 🔒 Security
 - **Pair Programming approval coverage** (Issue #9): `send_input` now always follows command-confirmation settings after escape decoding; sensitive SFTP operations are independently controlled by the SFTP confirmation setting.
+- **Authentication response approval**: keyboard-interactive responses follow Pair Programming confirmation, while credential values remain excluded from confirmation details and logs.
 - **Complete approval payloads**: confirmation dialogs show the complete decoded terminal input or SFTP write content rather than a truncated preview.
 - **Loopback hardening**: the service binds and publishes only `127.0.0.1`; Host and Origin validation now reject non-loopback and wrong-port requests across MCP endpoints.
 - **Direct tool API disabled by default**: the compatibility-only `/api/tool/:name` endpoint requires explicit configuration.
 
 ### 🐛 Fixed
+- **Tabby 1.0.235 startup compatibility**: tolerate `ConfigService.store` being unavailable during early Angular service construction instead of forcing Tabby into third-party-plugin safe mode.
 - **Issue #5 — restart after an unclean shutdown**: added single-flight server startup, stop-aware startup cancellation, retry/backoff, stale-instance detection, and authenticated same-install port handover.
 - **Issue #7 — terminal focus and IME disruption**: replaced blocking browser dialogs with queued non-blocking dialogs that restore the previous focus after resolving.
 - **Streamable HTTP conformance**: delegated GET and DELETE handling to the MCP SDK so session, protocol, Accept-header, standalone SSE, and one-stream validation are enforced consistently.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 **A Comprehensive MCP Server Plugin for Tabby Terminal**
 
-*Connect AI assistants to your terminal with full control — 35 MCP tools including SFTP support*
+*Connect AI assistants to your terminal with full control — 36 MCP tools including SFTP support*
 
 [English](README.md) | [中文](README_CN.md)
 
@@ -85,7 +85,7 @@
 </div>
 
 
-> **Safety model (v1.6.3):** Pair Programming Mode gates `exec_command`, `send_input`, and sensitive SFTP operations with a non-blocking approval dialog that automatically rejects after two minutes. The dialog restores terminal focus to avoid Electron/xterm keyboard and IME issues. Read-only transfer-status tools and emergency `abort_command` remain available without approval. Network access is restricted to loopback (`127.0.0.1`), Origin validation is applied to both MCP transports, and the direct tool API is disabled by default.
+> **Safety model (v1.6.3):** Pair Programming Mode gates `exec_command`, `send_input`, keyboard-interactive authentication responses, and sensitive SFTP operations with a non-blocking approval dialog that automatically rejects after two minutes. Authentication response values are never shown in confirmation details. The dialog restores terminal focus to avoid Electron/xterm keyboard and IME issues. Read-only transfer-status tools and emergency `abort_command` remain available without approval. Network access is restricted to loopback (`127.0.0.1`), Origin validation is applied to both MCP transports, and the direct tool API is disabled by default.
 
 ---
 
@@ -237,13 +237,14 @@ For clients that don't support SSE, use the STDIO bridge:
 
 ## 🛠️ Available Tools
 
-### Terminal Control (8)
+### Terminal Control (9)
 
 | Tool | Description |
 |------|-------------|
 | `get_session_list` | List all terminal sessions with **stable UUIDs** and metadata |
 | `exec_command` | Execute command with flexible session targeting |
 | `send_input` | Send interactive input (Ctrl+C, etc) |
+| `submit_keyboard_interactive_response` | Submit MFA, password, or other SSH keyboard-interactive responses |
 | `get_terminal_buffer` | Read terminal buffer (defaults to active session) |
 | `abort_command` | Abort running command |
 | `get_command_status` | Monitor active commands |
@@ -397,7 +398,8 @@ This project builds upon the work of [tabby-mcp-server](https://github.com/thuan
 - Fixed [Issue #5](https://github.com/GentlemanHu/Tabby-MCP/issues/5): loopback-only bind, startup retry, stale-instance detection, and authenticated same-install port handover.
 - Fixed Legacy SSE JSON body handling for SDK 1.25.2, session cleanup, stale Streamable HTTP session handling, Origin validation, fish active environment probes, SFTP locator consistency, and STDIO reconnect/framing behavior.
 - Pinned `@modelcontextprotocol/sdk` to 1.25.2, committed `package-lock.json`, and added typecheck/smoke/build quality gates.
-- Tool count is now documented accurately: 35 total (34 normally visible; `get_session_environment` is optional and disabled by default).
+- Added `submit_keyboard_interactive_response` for SSH keyboard-interactive authentication, including MFA/TOTP prompts. Pair Programming confirmation shows only the response count, never credential values.
+- Tool count is now documented accurately: 36 total (35 normally visible; `get_session_environment` is optional and disabled by default).
 
 See [CHANGELOG.md](CHANGELOG.md) for the complete version history.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -14,7 +14,7 @@
 
 **Tabby 终端的全功能 MCP 服务器插件**
 
-*将 AI 助手连接到您的终端 — 35 个 MCP 工具，包含 SFTP 支持*
+*将 AI 助手连接到您的终端 — 36 个 MCP 工具，包含 SFTP 支持*
 
 [English](README.md) | [中文](README_CN.md)
 
@@ -85,7 +85,7 @@
 </div>
 
 
-> **v1.6.3 安全模型：** 结对编程模式通过非阻塞确认对话框保护 `exec_command`、`send_input` 和敏感 SFTP 操作；两分钟无人处理时自动拒绝。对话框关闭后会恢复终端焦点，避免 Electron/xterm 的键盘和输入法问题。只读的传输状态工具和用于紧急中止的 `abort_command` 无需确认。网络仅限本机回环地址（`127.0.0.1`），两种 MCP 传输均验证 Origin，直连工具 API 默认关闭。
+> **v1.6.3 安全模型：** 结对编程模式通过非阻塞确认对话框保护 `exec_command`、`send_input`、键盘交互式认证响应和敏感 SFTP 操作；两分钟无人处理时自动拒绝。认证响应值绝不会显示在确认详情中。对话框关闭后会恢复终端焦点，避免 Electron/xterm 的键盘和输入法问题。只读的传输状态工具和用于紧急中止的 `abort_command` 无需确认。网络仅限本机回环地址（`127.0.0.1`），两种 MCP 传输均验证 Origin，直连工具 API 默认关闭。
 
 ---
 
@@ -199,13 +199,14 @@ npm run build
 
 ## 🛠️ 可用工具
 
-### 终端控制（8 个）
+### 终端控制（9 个）
 
 | 工具 | 说明 |
 |------|------|
 | `get_session_list` | 列出所有终端会话（**包含稳定 UUID**） |
 | `exec_command` | 执行命令（支持多种定位方式） |
 | `send_input` | 发送交互式输入 (Ctrl+C 等) |
+| `submit_keyboard_interactive_response` | 提交 MFA、密码或其他 SSH 键盘交互式认证响应 |
 | `get_terminal_buffer` | 读取终端缓冲区（默认使用活跃会话） |
 | `abort_command` | 中止正在运行的命令 |
 | `get_command_status` | 监控活动命令状态 |
@@ -359,7 +360,8 @@ npm run build
 - 修复 [Issue #5](https://github.com/GentlemanHu/Tabby-MCP/issues/5)：仅监听回环地址、启动退避重试、旧实例识别，以及同一安装实例间经过认证的端口交接。
 - 修复 SDK 1.25.2 下 Legacy SSE JSON 请求体处理、会话清理、失效 Streamable HTTP 会话、Origin 校验、fish 主动环境探测、SFTP 定位器一致性及 STDIO 重连/消息帧问题。
 - 固定 `@modelcontextprotocol/sdk` 为 1.25.2，提交 `package-lock.json`，并新增类型检查、冒烟测试和构建质量门禁。
-- 工具数量文档已校正为 35 个（通常可见 34 个；`get_session_environment` 为可选工具且默认关闭）。
+- 新增 `submit_keyboard_interactive_response`，用于处理 MFA/TOTP 等 SSH 键盘交互式认证；结对编程确认只显示响应数量，不显示认证值。
+- 工具数量文档已校正为 36 个（通常可见 35 个；`get_session_environment` 为可选工具且默认关闭）。
 
 完整版本历史请查看 [CHANGELOG.md](CHANGELOG.md)。
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tabby-mcp-server",
   "version": "1.6.3-rc.1",
-  "description": "MCP (Model Context Protocol) server plugin for Tabby terminal - Complete terminal control with 35 MCP tools including SFTP file transfer",
+  "description": "MCP (Model Context Protocol) server plugin for Tabby terminal - Complete terminal control with 36 MCP tools including SFTP file transfer",
   "homepage": "https://github.com/GentlemanHu/Tabby-MCP",
   "repository": {
     "type": "git",

--- a/scripts/smoke-test.js
+++ b/scripts/smoke-test.js
@@ -15,8 +15,8 @@ function testToolCount() {
         'src/tools/sftp.ts'
     ];
     const counts = files.map(file => (read(file).match(/this\.registerTool\(/g) || []).length);
-    assert.deepEqual(counts, [8, 15, 12], 'Unexpected tool count per category');
-    assert.equal(counts.reduce((sum, count) => sum + count, 0), 35, 'Expected 35 registered MCP tools');
+    assert.deepEqual(counts, [9, 15, 12], 'Unexpected tool count per category');
+    assert.equal(counts.reduce((sum, count) => sum + count, 0), 36, 'Expected 36 registered MCP tools');
 }
 
 function testNoBlockingBrowserDialogs() {
@@ -70,6 +70,25 @@ function testApprovalAndCancellationGuards() {
     const sendInput = terminal.slice(terminal.indexOf("name: 'send_input'"), terminal.indexOf('private parseEnvironmentFromBuffer'));
     assert.equal(sendInput.includes('confirmFileOperations'), false, 'send_input approval must not depend on the SFTP confirmation option');
     assert.match(sendInput, /JSON\.stringify\(processedInput\)/, 'send_input must show the decoded terminal input');
+    const keyboardInteractive = terminal.slice(
+        terminal.indexOf("name: 'submit_keyboard_interactive_response'"),
+        terminal.indexOf('private parseEnvironmentFromBuffer')
+    );
+    assert.match(
+        keyboardInteractive,
+        /showOperationConfirmation\([\s\S]*'submit_keyboard_interactive_response'/,
+        'keyboard-interactive authentication must require Pair Programming confirmation'
+    );
+    assert.match(
+        keyboardInteractive,
+        /`\$\{providedResponses\.length\} keyboard-interactive response\(s\)`/,
+        'keyboard-interactive confirmation must show only the response count'
+    );
+    assert.equal(
+        keyboardInteractive.includes('submit:'),
+        false,
+        'keyboard-interactive responses must not remain staged without submission'
+    );
     assert.equal(/else; printf 'shell'; end; end/.test(terminal), false, 'fish probe must close its if chain exactly once');
 
     const sftp = read('src/tools/sftp.ts');
@@ -91,6 +110,13 @@ function testTranslations() {
         assert.ok(en[key], `Missing English translation: ${key}`);
         assert.ok(zh[key], `Missing Chinese translation: ${key}`);
     }
+
+    const i18nService = read('src/services/i18n.service.ts');
+    assert.match(
+        i18nService,
+        /config\.store\?\.language/,
+        'i18n initialization must tolerate ConfigService.store not being ready yet'
+    );
 }
 
 function testPinnedSdkAndLockfile() {

--- a/src/services/i18n.service.ts
+++ b/src/services/i18n.service.ts
@@ -30,7 +30,7 @@ export class McpI18nService {
 
     private updateLocale(): void {
         // Tabby stores language setting in config.store.language
-        const newLocale = this.config.store.language || defaultLocale;
+        const newLocale = this.config.store?.language || defaultLocale;
         if (newLocale !== this.currentLocale) {
             this.currentLocale = newLocale;
             this.logger.debug(`[i18n] Locale changed to: ${newLocale}`);

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -323,14 +323,20 @@ export class TerminalToolCategory extends BaseToolCategory {
             name: prompt.name ?? '',
             instruction: prompt.instruction ?? '',
             prompts: Array.isArray(prompt.prompts)
-                ? prompt.prompts.map((p: any, index: number) => ({
-                    index,
-                    prompt: p?.prompt ?? '',
-                    echo: p?.echo !== false,
-                    isPassword: typeof prompt.isAPasswordPrompt === 'function'
-                        ? Boolean(prompt.isAPasswordPrompt(index))
-                        : false
-                }))
+                ? prompt.prompts.map((entry: any, index: number) => {
+                    // Current Tabby uses strings; older releases exposed prompt objects.
+                    const text = typeof entry === 'string'
+                        ? entry
+                        : String(entry?.prompt ?? '');
+                    return {
+                        index,
+                        prompt: text,
+                        echo: typeof entry === 'object' && entry !== null
+                            ? entry.echo !== false
+                            : true,
+                        isPassword: /password/i.test(text)
+                    };
+                })
                 : [],
             responseCount: Array.isArray(prompt.responses) ? prompt.responses.length : 0
         };
@@ -690,7 +696,6 @@ Session targeting: sessionId (recommended) > tabIndex > title > profileName`,
             schema: z.object({
                 response: z.string().optional().describe('Single response for prompts with one field, such as a 6-digit TOTP code'),
                 responses: z.array(z.string()).optional().describe('Responses for multi-prompt keyboard-interactive auth, in prompt order'),
-                submit: z.boolean().optional().describe('Whether to submit after filling responses (default: true)'),
                 sessionId: z.string().optional().describe('Stable session ID (recommended)'),
                 tabIndex: z.number().optional().describe('Tab index (legacy)'),
                 title: z.string().optional().describe('Match by title'),
@@ -699,13 +704,12 @@ Session targeting: sessionId (recommended) > tabIndex > title > profileName`,
             handler: async (params: {
                 response?: string;
                 responses?: string[];
-                submit?: boolean;
                 sessionId?: string;
                 tabIndex?: number;
                 title?: string;
                 profileName?: string;
             }) => {
-                const { response, responses, submit, sessionId, tabIndex, title, profileName } = params;
+                const { response, responses, sessionId, tabIndex, title, profileName } = params;
                 const session = this.findSessionByLocator({ sessionId, tabIndex, title, profileName });
 
                 if (!session) {
@@ -775,19 +779,47 @@ Session targeting: sessionId (recommended) > tabIndex > title > profileName`,
                     };
                 }
 
+                if (typeof prompt.respond !== 'function') {
+                    return {
+                        content: [{
+                            type: 'text', text: JSON.stringify({
+                                success: false,
+                                sessionId: session.sessionId,
+                                error: 'Keyboard-interactive prompt does not expose respond()'
+                            })
+                        }]
+                    };
+                }
+
+                const pairMode = this.config.store.mcp?.pairProgrammingMode;
+                if (pairMode?.enabled && pairMode?.showConfirmationDialog) {
+                    const confirmed = await this.dialogService.showOperationConfirmation(
+                        'submit_keyboard_interactive_response',
+                        session.tab.title || `Terminal ${session.tabIndex}`,
+                        `${providedResponses.length} keyboard-interactive response(s)`
+                    );
+                    if (!confirmed) {
+                        return {
+                            content: [{
+                                type: 'text', text: JSON.stringify({
+                                    success: false,
+                                    sessionId: session.sessionId,
+                                    error: 'Keyboard-interactive response rejected by user'
+                                })
+                            }]
+                        };
+                    }
+                }
+
+                const previousResponses = [...prompt.responses];
                 try {
                     providedResponses.forEach((value, index) => {
                         prompt.responses[index] = value;
                     });
 
-                    if (submit !== false) {
-                        if (typeof prompt.respond !== 'function') {
-                            throw new Error('Keyboard-interactive prompt does not expose respond()');
-                        }
-                        prompt.respond();
-                        (session.tab as any).activeKIPrompt = null;
-                        (session.tab as any).frontend?.focus?.();
-                    }
+                    prompt.respond();
+                    (session.tab as any).activeKIPrompt = null;
+                    (session.tab as any).frontend?.focus?.();
 
                     this.logger.info(`Submitted keyboard-interactive response for session ${session.sessionId}`);
                     return {
@@ -795,15 +827,14 @@ Session targeting: sessionId (recommended) > tabIndex > title > profileName`,
                             type: 'text', text: JSON.stringify({
                                 success: true,
                                 sessionId: session.sessionId,
-                                submitted: submit !== false,
+                                submitted: true,
                                 responseCount: providedResponses.length,
-                                message: submit === false
-                                    ? 'Keyboard-interactive response filled but not submitted'
-                                    : 'Keyboard-interactive response submitted'
+                                message: 'Keyboard-interactive response submitted'
                             })
                         }]
                     };
                 } catch (error: any) {
+                    prompt.responses.splice(0, prompt.responses.length, ...previousResponses);
                     this.logger.error(`Error submitting keyboard-interactive response for session ${session.sessionId}:`, error);
                     return {
                         content: [{

--- a/src/tools/terminal.ts
+++ b/src/tools/terminal.ts
@@ -66,6 +66,7 @@ export class TerminalToolCategory extends BaseToolCategory {
         this.registerTool(this.createGetSessionListTool());
         this.registerTool(this.createExecCommandTool());
         this.registerTool(this.createSendInputTool());
+        this.registerTool(this.createSubmitKeyboardInteractiveResponseTool());
         this.registerTool(this.createGetTerminalBufferTool());
         this.registerTool(this.createAbortCommandTool());
         this.registerTool(this.createGetCommandStatusTool());
@@ -309,6 +310,32 @@ export class TerminalToolCategory extends BaseToolCategory {
         return null;
     }
 
+    private getKeyboardInteractivePrompt(session: TerminalSessionWithTab): any | null {
+        return (session.tab as any).activeKIPrompt ?? null;
+    }
+
+    private describeKeyboardInteractivePrompt(prompt: any): any | undefined {
+        if (!prompt) {
+            return undefined;
+        }
+
+        return {
+            name: prompt.name ?? '',
+            instruction: prompt.instruction ?? '',
+            prompts: Array.isArray(prompt.prompts)
+                ? prompt.prompts.map((p: any, index: number) => ({
+                    index,
+                    prompt: p?.prompt ?? '',
+                    echo: p?.echo !== false,
+                    isPassword: typeof prompt.isAPasswordPrompt === 'function'
+                        ? Boolean(prompt.isAPasswordPrompt(index))
+                        : false
+                }))
+                : [],
+            responseCount: Array.isArray(prompt.responses) ? prompt.responses.length : 0
+        };
+    }
+
     /**
      * Tool: Get list of terminal sessions with enhanced metadata
      * Now includes detailed split pane information
@@ -330,6 +357,7 @@ For split panes:
                 const sessions = this.findTerminalSessions();
                 const result = sessions.map(s => {
                     const tabAny = s.tab as any;
+                    const keyboardInteractivePrompt = this.getKeyboardInteractivePrompt(s);
                     return {
                         sessionId: s.sessionId,
                         tabIndex: s.tabIndex,
@@ -337,6 +365,9 @@ For split panes:
                         type: s.tab.constructor.name,
                         isActive: this.app.activeTab === s.tabParent,
                         hasActiveCommand: this._activeCommands.has(s.sessionId),
+                        sshConnected: tabAny.sshSession?.open === true,
+                        keyboardInteractivePending: Boolean(keyboardInteractivePrompt),
+                        keyboardInteractivePrompt: this.describeKeyboardInteractivePrompt(keyboardInteractivePrompt),
                         profile: tabAny.profile ? {
                             id: tabAny.profile.id,
                             name: tabAny.profile.name,
@@ -635,6 +666,151 @@ Special keys: \\x03 (Ctrl+C), \\x04 (Ctrl+D), \\x1b (Escape), \\r (Enter)`,
                                 success: false,
                                 error: `Failed to send input: ${error.message}. Session might be disconnected.`,
                                 sessionId: session.sessionId
+                            })
+                        }]
+                    };
+                }
+            }
+        };
+    }
+
+    /**
+     * Tool: Submit response to Tabby's SSH keyboard-interactive auth panel
+     */
+    private createSubmitKeyboardInteractiveResponseTool(): McpTool {
+        return {
+            name: 'submit_keyboard_interactive_response',
+            description: `Submit response(s) to an active SSH keyboard-interactive authentication prompt.
+Use this for MFA/TOTP prompts shown by Tabby's SSH authentication panel, such as Jumpserver MFA.
+
+This tool targets Tabby's activeKIPrompt object directly; it is different from send_input,
+which writes to the terminal pty and cannot answer Tabby's auth form.
+
+Session targeting: sessionId (recommended) > tabIndex > title > profileName`,
+            schema: z.object({
+                response: z.string().optional().describe('Single response for prompts with one field, such as a 6-digit TOTP code'),
+                responses: z.array(z.string()).optional().describe('Responses for multi-prompt keyboard-interactive auth, in prompt order'),
+                submit: z.boolean().optional().describe('Whether to submit after filling responses (default: true)'),
+                sessionId: z.string().optional().describe('Stable session ID (recommended)'),
+                tabIndex: z.number().optional().describe('Tab index (legacy)'),
+                title: z.string().optional().describe('Match by title'),
+                profileName: z.string().optional().describe('Match by profile name')
+            }),
+            handler: async (params: {
+                response?: string;
+                responses?: string[];
+                submit?: boolean;
+                sessionId?: string;
+                tabIndex?: number;
+                title?: string;
+                profileName?: string;
+            }) => {
+                const { response, responses, submit, sessionId, tabIndex, title, profileName } = params;
+                const session = this.findSessionByLocator({ sessionId, tabIndex, title, profileName });
+
+                if (!session) {
+                    return {
+                        content: [{
+                            type: 'text', text: JSON.stringify({
+                                success: false,
+                                error: 'No matching terminal session found',
+                                hint: 'Use get_session_list to see available sessions'
+                            })
+                        }]
+                    };
+                }
+
+                const prompt = this.getKeyboardInteractivePrompt(session);
+                if (!prompt) {
+                    return {
+                        content: [{
+                            type: 'text', text: JSON.stringify({
+                                success: false,
+                                sessionId: session.sessionId,
+                                keyboardInteractivePending: false,
+                                error: 'No active keyboard-interactive prompt on this session'
+                            })
+                        }]
+                    };
+                }
+
+                const providedResponses = responses ?? (response !== undefined ? [response] : undefined);
+                if (!providedResponses || providedResponses.length === 0) {
+                    return {
+                        content: [{
+                            type: 'text', text: JSON.stringify({
+                                success: false,
+                                sessionId: session.sessionId,
+                                keyboardInteractivePending: true,
+                                keyboardInteractivePrompt: this.describeKeyboardInteractivePrompt(prompt),
+                                error: 'Provide response or responses'
+                            })
+                        }]
+                    };
+                }
+
+                if (!Array.isArray(prompt.responses) || !Array.isArray(prompt.prompts)) {
+                    return {
+                        content: [{
+                            type: 'text', text: JSON.stringify({
+                                success: false,
+                                sessionId: session.sessionId,
+                                error: 'Active keyboard-interactive prompt has an unexpected shape',
+                                keyboardInteractivePrompt: this.describeKeyboardInteractivePrompt(prompt)
+                            })
+                        }]
+                    };
+                }
+
+                if (providedResponses.length !== prompt.prompts.length) {
+                    return {
+                        content: [{
+                            type: 'text', text: JSON.stringify({
+                                success: false,
+                                sessionId: session.sessionId,
+                                error: `Expected ${prompt.prompts.length} response(s), got ${providedResponses.length}`,
+                                keyboardInteractivePrompt: this.describeKeyboardInteractivePrompt(prompt)
+                            })
+                        }]
+                    };
+                }
+
+                try {
+                    providedResponses.forEach((value, index) => {
+                        prompt.responses[index] = value;
+                    });
+
+                    if (submit !== false) {
+                        if (typeof prompt.respond !== 'function') {
+                            throw new Error('Keyboard-interactive prompt does not expose respond()');
+                        }
+                        prompt.respond();
+                        (session.tab as any).activeKIPrompt = null;
+                        (session.tab as any).frontend?.focus?.();
+                    }
+
+                    this.logger.info(`Submitted keyboard-interactive response for session ${session.sessionId}`);
+                    return {
+                        content: [{
+                            type: 'text', text: JSON.stringify({
+                                success: true,
+                                sessionId: session.sessionId,
+                                submitted: submit !== false,
+                                responseCount: providedResponses.length,
+                                message: submit === false
+                                    ? 'Keyboard-interactive response filled but not submitted'
+                                    : 'Keyboard-interactive response submitted'
+                            })
+                        }]
+                    };
+                } catch (error: any) {
+                    this.logger.error(`Error submitting keyboard-interactive response for session ${session.sessionId}:`, error);
+                    return {
+                        content: [{
+                            type: 'text', text: JSON.stringify({
+                                success: false,
+                                sessionId: session.sessionId,
+                                error: `Failed to submit keyboard-interactive response: ${error.message || error}`
                             })
                         }]
                     };


### PR DESCRIPTION
## Summary

Adds an MCP tool for answering Tabby's SSH keyboard-interactive authentication prompts, such as MFA/TOTP prompts shown by Jumpserver.

## Motivation

`send_input` writes to the terminal pty. During SSH keyboard-interactive authentication, Tabby renders a separate auth panel backed by the SSH tab's `activeKIPrompt`, so terminal input does not reach the MFA response field. This change adds a dedicated tool that writes responses to the active prompt and calls `respond()`, matching Tabby's own auth panel flow.

## Changes

- Adds `submit_keyboard_interactive_response` for one-field or multi-field keyboard-interactive prompts.
- Reports `sshConnected`, `keyboardInteractivePending`, and non-secret prompt metadata in `get_session_list`.
- Keeps prompt responses out of returned metadata.

## Validation

- Ran `npm run build` successfully.
- Build completed with two existing warnings from Sass legacy JS API usage and Express dynamic require.
